### PR TITLE
Add search query feature to Flux

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import (
 func main() {
   tdaSession := tda.Session{
      Refresh: "<YOUR_REFRESH_TOKEN>,
-     ConsumerKey: "<YOUR_CONSUMER_KEY>,
+     ConsumerKey: "<YOUR_CONSUMER_KEY>",
      RootUrl: "https://api.tdameritrade.com/v1",
      
   }

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,6 @@
+package flux
+
+type storedCache struct {
+	Chart  chartStoredCache  `json:"chart"`
+	Search searchStoredCache `json:"search"`
+}

--- a/charts.go
+++ b/charts.go
@@ -204,10 +204,10 @@ func (s *Session) RequestChart(specs ChartRequestSignature) (*chartStoredCache, 
 	return nil, nil
 }
 
-// RequestMultipleCharts takes a slice of ChartRequestSignature as an input and responds with a
-// chartStoredCache object, it utilizes the cached if it can (with updated diffs), or
-// else it makes a new request and waits for it - if a ticker does not load in
-// time, ErrNotReceviedInTime is sent as an error
+// RequestMultipleCharts takes a slice of ChartRequestSignature as an input and
+// responds with a a slice of chart objects, it utilizes the cached if it can
+// (with updated diffs), or else it makes a new request and waits for it - if a
+// ticker does not load in time, ErrNotReceviedInTime is sent as an error
 func (s *Session) RequestMultipleCharts(specsSlice []ChartRequestSignature) ([]*chartStoredCache, []ChartRequestSignature) {
 
 	payload := gatewayRequestLoad{}

--- a/conn.go
+++ b/conn.go
@@ -24,7 +24,8 @@ func New(creds tda.Session) (*Session, error) {
 	s.ConfigUrl = "https://trade.thinkorswim.com/v1/api/config"
 	s.CurrentState = storedCache{}
 	s.TransactionChannel = make(chan storedCache)
-	s.RequestVers = make(map[string]int)
+	s.ChartRequestVers = make(map[string]int)
+	s.SearchRequestVers = make(map[string]int)
 
 	return s, nil
 }
@@ -168,6 +169,9 @@ func (s *Session) listen() {
 
 		case `"chart"`:
 			s.chartHandler(message, parsedJson)
+
+		case `"instrument_search"`:
+			s.searchHandler(message, parsedJson)
 		}
 	}
 }

--- a/conn.go
+++ b/conn.go
@@ -23,7 +23,7 @@ func New(creds tda.Session) (*Session, error) {
 
 	s.ConfigUrl = "https://trade.thinkorswim.com/v1/api/config"
 	s.CurrentState = []byte(`{"data": ""}`)
-	s.TransactionChannel = make(chan cachedData)
+	s.TransactionChannel = make(chan chartStoredCache)
 	s.RequestVers = make(map[string]int)
 
 	return s, nil

--- a/conn.go
+++ b/conn.go
@@ -22,8 +22,8 @@ func New(creds tda.Session) (*Session, error) {
 	}
 
 	s.ConfigUrl = "https://trade.thinkorswim.com/v1/api/config"
-	s.CurrentState = []byte(`{"data": ""}`)
-	s.TransactionChannel = make(chan chartStoredCache)
+	s.CurrentState = storedCache{}
+	s.TransactionChannel = make(chan storedCache)
 	s.RequestVers = make(map[string]int)
 
 	return s, nil

--- a/search.go
+++ b/search.go
@@ -1,0 +1,116 @@
+package flux
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/Jeffail/gabs"
+)
+
+func (s *Session) searchHandler(msg []byte, patch *gabs.Container) {
+	patch = patch.S("payloadPatches", "0", "patches", "0")
+
+	var state searchStoredCache
+	err := json.Unmarshal(patch.Bytes(), &state)
+	if err != nil {
+		return
+	}
+
+	s.CurrentState.Search = state
+	s.TransactionChannel <- s.CurrentState
+}
+
+type SearchRequestSignature struct {
+	Pattern  string
+	Limit    int
+	UniqueID string
+}
+
+func (r *SearchRequestSignature) shortName() string {
+	return fmt.Sprintf("SEARCH#%s@%d", r.Pattern, r.Limit)
+}
+
+type searchStoredCache struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value struct {
+		Instruments []struct {
+			Composite              bool   `json:"composite"`
+			Cusip                  string `json:"cusip,omitempty"`
+			DaysToExpiration       int    `json:"daysToExpiration"`
+			Description            string `json:"description"`
+			DisplaySymbol          string `json:"displaySymbol"`
+			ExtoEnabled            bool   `json:"extoEnabled"`
+			Flags                  int    `json:"flags"`
+			FractionalType         string `json:"fractionalType"`
+			FutureOption           bool   `json:"futureOption"`
+			HasOptions             bool   `json:"hasOptions"`
+			ID                     int    `json:"id"`
+			Industry               int    `json:"industry"`
+			InstrumentType         string `json:"instrumentType"`
+			IsFutureProduct        bool   `json:"isFutureProduct"`
+			Multiplier             int    `json:"multiplier"`
+			RootDisplaySymbol      string `json:"rootDisplaySymbol"`
+			RootSymbol             string `json:"rootSymbol"`
+			SourceType             string `json:"sourceType"`
+			Spc                    int    `json:"spc"`
+			SpreadDaysToExpiration string `json:"spreadDaysToExpiration"`
+			SpreadsSupported       bool   `json:"spreadsSupported"`
+			Symbol                 string `json:"symbol"`
+			Tradeable              bool   `json:"tradeable"`
+		} `json:"instruments"`
+		RequestID  string `json:"requestId"`
+		RequestVer int    `json:"requestVer"`
+		Service    string `json:"service"`
+	} `json:"value"`
+}
+
+func (s *Session) RequestSearch(spec SearchRequestSignature) (*searchStoredCache, error) {
+	uniqueID := fmt.Sprintf("%s-%d", spec.shortName(), s.SearchRequestVers[spec.shortName()])
+	spec.UniqueID = uniqueID
+
+	req := gatewayRequest{
+		Service: "instrument_search",
+		Limit:   5,
+		Pattern: spec.Pattern,
+		Ver:     s.SearchRequestVers[spec.shortName()],
+		ID:      spec.UniqueID,
+	}
+	s.SearchRequestVers[spec.shortName()]++
+
+	payload := gatewayRequestLoad{[]gatewayRequest{req}}
+	s.wsConn.WriteJSON(payload)
+
+	internalChannel := make(chan storedCache)
+	ctx, _ := context.WithTimeout(context.Background(), time.Second)
+
+	go func() {
+		for {
+			select {
+
+			case recvPayload := <-s.TransactionChannel:
+				if recvPayload.Search.Value.RequestID == spec.UniqueID {
+					internalChannel <- recvPayload
+					return
+				}
+
+			case <-ctx.Done():
+				return
+
+			}
+		}
+	}()
+
+	select {
+
+	case recvPayload := <-internalChannel:
+		return &recvPayload.Search, nil
+
+	case <-ctx.Done():
+		return nil, ErrNotReceivedInTime
+
+	}
+
+}

--- a/search.go
+++ b/search.go
@@ -22,12 +22,19 @@ func (s *Session) searchHandler(msg []byte, patch *gabs.Container) {
 	s.TransactionChannel <- s.CurrentState
 }
 
+// SearchRequest Signature is the parameter for a search request
 type SearchRequestSignature struct {
-	Pattern  string
-	Limit    int
+	// pattern is the search query for the request
+	Pattern string
+
+	// limit is the number of results to pull up, typically 3-5 is normal
+	Limit int
+
+	// internal use only
 	UniqueID string
 }
 
+// shortname presented as SEARCH#PATTERN@LIMIT
 func (r *SearchRequestSignature) shortName() string {
 	return fmt.Sprintf("SEARCH#%s@%d", r.Pattern, r.Limit)
 }
@@ -67,6 +74,10 @@ type searchStoredCache struct {
 	} `json:"value"`
 }
 
+// RequestSearch takes a SearchRequestSignature as an input and responds with a
+// search query, it does not utilize a cache (although it maintains one) so the
+// query made will be up to date with the servers. If the query is not loaded
+// within a certain time, ErrNotReceivedInTime is sent as an error
 func (s *Session) RequestSearch(spec SearchRequestSignature) (*searchStoredCache, error) {
 	uniqueID := fmt.Sprintf("%s-%d", spec.shortName(), s.SearchRequestVers[spec.shortName()])
 	spec.UniqueID = uniqueID

--- a/search.go
+++ b/search.go
@@ -18,6 +18,7 @@ func (s *Session) searchHandler(msg []byte, patch *gabs.Container) {
 		return
 	}
 
+	state.Path = "/instrument_search"
 	s.CurrentState.Search = state
 	s.TransactionChannel <- s.CurrentState
 }

--- a/session.go
+++ b/session.go
@@ -15,12 +15,12 @@ type Session struct {
 	ConfigUrl          string
 	CurrentState       []byte
 	CurrentChartHash   string
-	TransactionChannel chan cachedData
+	TransactionChannel chan chartStoredCache
 	RequestVers        map[string]int
 }
 
-func (s *Session) dataAsChartObject() (*cachedData, error) {
-	data := keyCachedData{}
+func (s *Session) dataAsChartObject() (*chartStoredCache, error) {
+	data := storedCache{}
 	err := json.Unmarshal(s.CurrentState, &data)
 	if err != nil {
 		return nil, err

--- a/session.go
+++ b/session.go
@@ -15,7 +15,8 @@ type Session struct {
 	ConfigUrl          string
 	CurrentState       storedCache
 	TransactionChannel chan storedCache
-	RequestVers        map[string]int
+	ChartRequestVers   map[string]int
+	SearchRequestVers  map[string]int
 }
 
 // Gateway returns the gateway URL as a string for the live trading connection

--- a/session.go
+++ b/session.go
@@ -13,19 +13,9 @@ type Session struct {
 	TdaSession         tda.Session
 	wsConn             *websocket.Conn
 	ConfigUrl          string
-	CurrentState       []byte
-	CurrentChartHash   string
-	TransactionChannel chan chartStoredCache
+	CurrentState       storedCache
+	TransactionChannel chan storedCache
 	RequestVers        map[string]int
-}
-
-func (s *Session) dataAsChartObject() (*chartStoredCache, error) {
-	data := storedCache{}
-	err := json.Unmarshal(s.CurrentState, &data)
-	if err != nil {
-		return nil, err
-	}
-	return &data.Data, nil
 }
 
 // Gateway returns the gateway URL as a string for the live trading connection

--- a/types.go
+++ b/types.go
@@ -40,6 +40,8 @@ type gatewayRequest struct {
 	Ver               int      `json:"ver,omitempty"`
 	Domain            string   `json:"domain,omitempty"`
 	Platform          string   `json:"platform,omitempty"`
+	Limit             int      `json:"limit,omitempty"`
+	Pattern           string   `json:"pattern,omitempty"`
 	Token             string   `json:"token,omitempty"`
 	AccessToken       string   `json:"accessToken,omitempty"`
 	Tag               string   `json:"tag,omitempty"`


### PR DESCRIPTION
Flux is now capable of running a search query using `instrument_search` as documented in `docs/`, this pull request refactors the way caching works and has been tested.